### PR TITLE
Fixed ArgumentOutOfRangeException message

### DIFF
--- a/CoinpaprikaAPI/Client.cs
+++ b/CoinpaprikaAPI/Client.cs
@@ -238,7 +238,7 @@ namespace CoinpaprikaAPI
                 throw new NotSupportedException("id must be defined");
 
             if (limit < 1 || limit > 366)
-                throw new ArgumentOutOfRangeException(nameof(limit), "limit must be between 1 and 250");
+                throw new ArgumentOutOfRangeException(nameof(limit), "limit must be between 1 and 366");
 
 
             var client = BaseClient.GetClient();


### PR DESCRIPTION
Fixed wrong number in ArgumentOutOfRangeException message for GetHistoricalOhlcForCoinAsync()